### PR TITLE
Bug fix: wrong current working directory

### DIFF
--- a/modules.nf
+++ b/modules.nf
@@ -514,6 +514,11 @@ process reorganize_markers {
 set -e
 
 mkdir fastas_by_marker
+
+# PWD is /, must cd to the directory before running script
+BASEDIR=`dirname \$0`
+cd \$BASEDIR
+
 reorganize_markers.py
 """
 }


### PR DESCRIPTION
We faced `reorganize_markers.py killed` errors several times, without any clue of what's wrong. Then I tried `bash .command.run` with customized `.command.sh` to get into the interactive docker, and found out that reorganize_markers.py was running under the root directory.(I've added `docker.runOptions = '-u $(id -u):$(id -g)'` to nextflow.config, don't know if it's related to this bug)

Guess there would be better solution to change the working directory with nextflow's code, but I'm not familiar with this language, and don't know if my code is suitable. Please make a decision at your will, thanks.