### PR TITLE
fix "touch: cannot touch '.command.trace': Permission denied" error

### DIFF
--- a/._wb/launcher/gigmap_docker/run.sh
+++ b/._wb/launcher/gigmap_docker/run.sh
@@ -9,6 +9,8 @@ echo """
 docker.enabled = true
 report.enabled = true
 trace.enabled = true
+
+docker.runOptions = '-u $(id -u):$(id -g)'
 """ > nextflow.config
 
 cat nextflow.config


### PR DESCRIPTION
In my CentOS7 environment, I'm always facing the `touch: cannot touch '.command.trace': Permission denied` error when running any tool, I fix it with info found [here](https://groups.google.com/g/nextflow/c/sZEhsc4HbOQ?pli=1).

![image](https://user-images.githubusercontent.com/4575752/170249166-71c904fc-85c0-4454-815e-6578c61435b9.png)

And it seems not so easy to provide a `nextflow.config` of mine to Bash workbench as before. So I decided to create this PR.